### PR TITLE
trigger PostPublished when posts are published programmatically

### DIFF
--- a/class/Defaults/Trigger/Post/PostPublished.php
+++ b/class/Defaults/Trigger/Post/PostPublished.php
@@ -28,6 +28,7 @@ class PostPublished extends PostTrigger {
 			'name'      => sprintf( __( '%s published', 'notification' ), parent::get_post_type_name( $post_type ) ),
 		) );
 
+		$this->add_action( 'new_to_publish', 10 );
 		$this->add_action( 'auto-draft_to_publish', 10 );
 		$this->add_action( 'draft_to_publish', 10 );
 		$this->add_action( 'pending_to_publish', 10 );


### PR DESCRIPTION
When posts are published programmatically with `wp_insert_post()`, e.g. via the REST API, the status transitions from `new` to `publish`. The current version of PostPublished doesn't listen for this transition, and therefore misses posts that are published via `wp_insert_post()`.