### PR TITLE
fix user_id assignment

### DIFF
--- a/class/Defaults/Trigger/User/UserDeleted.php
+++ b/class/Defaults/Trigger/User/UserDeleted.php
@@ -35,7 +35,7 @@ class UserDeleted extends Abstracts\Trigger {
 	 */
 	public function action() {
 
-		$this->user_id     = $this->callback_args[1]->ID;
+		$this->user_id     = $this->callback_args[0];
 		$this->user_object = get_userdata( $this->user_id );
 		$this->user_meta   = get_user_meta( $this->user_id );
 


### PR DESCRIPTION
The user_id was assigned a non existing item in the callback array, which create a php error when attempting to delete a user. 