### PR TITLE
New option to allow unfiltered html in email body

### DIFF
--- a/class/Admin/PostData.php
+++ b/class/Admin/PostData.php
@@ -186,7 +186,7 @@ class PostData {
 
 	        }
 
-	        $notification_data = apply_filters( 'notification/allow_unfiltered_body', $notification_data, $ndata );
+	        $notification_data = apply_filters( 'notification/notification/form/data/values', $notification_data, $ndata );
 
 	        update_post_meta( $this->get_post_id(), $this->notification_data_key . $notification->get_slug(), $notification_data );
 

--- a/class/Admin/PostData.php
+++ b/class/Admin/PostData.php
@@ -157,8 +157,6 @@ class PostData {
 
 		}
 
-		$unfiltered_html = notification_get_setting( 'notifications/email/unfiltered_html' );
-
         // save all notification settings one by one.
         foreach ( notification_get_notifications() as $notification ) {
 
@@ -184,13 +182,11 @@ class PostData {
 	        		$user_data = null;
 	        	}
 
-	        	if ( $unfiltered_html && $field->get_raw_name() == 'body' ) {
-	        		$notification_data[ $field->get_raw_name() ] = $user_data;
-	        	} else {
-	        		$notification_data[ $field->get_raw_name() ] = $field->sanitize( $user_data );
-	        	}
+	        	$notification_data[ $field->get_raw_name() ] = $field->sanitize( $user_data );
 
 	        }
+
+	        $notification_data = apply_filters( 'notification/allow_unfiltered_body', $notification_data, $ndata['body'] );
 
 	        update_post_meta( $this->get_post_id(), $this->notification_data_key . $notification->get_slug(), $notification_data );
 

--- a/class/Admin/PostData.php
+++ b/class/Admin/PostData.php
@@ -186,7 +186,7 @@ class PostData {
 
 	        }
 
-	        $notification_data = apply_filters( 'notification/allow_unfiltered_body', $notification_data, $ndata['body'] );
+	        $notification_data = apply_filters( 'notification/allow_unfiltered_body', $notification_data, $ndata );
 
 	        update_post_meta( $this->get_post_id(), $this->notification_data_key . $notification->get_slug(), $notification_data );
 

--- a/class/Admin/PostData.php
+++ b/class/Admin/PostData.php
@@ -157,6 +157,8 @@ class PostData {
 
 		}
 
+		$unfiltered_html = notification_get_setting( 'notifications/email/unfiltered_html' );
+
         // save all notification settings one by one.
         foreach ( notification_get_notifications() as $notification ) {
 
@@ -171,7 +173,7 @@ class PostData {
 	            continue;
 	        }
 
-	        $notification_data = array();
+	    	$notification_data = array();
 
 	        // sanitize each field individually.
 	        foreach ( $notification->get_form_fields() as $field ) {
@@ -182,7 +184,11 @@ class PostData {
 	        		$user_data = null;
 	        	}
 
-	        	$notification_data[ $field->get_raw_name() ] = $field->sanitize( $user_data );
+	        	if ( $unfiltered_html && $field->get_raw_name() == 'body' ) {
+	        		$notification_data[ $field->get_raw_name() ] = $user_data;
+	        	} else {
+	        		$notification_data[ $field->get_raw_name() ] = $field->sanitize( $user_data );
+	        	}
 
 	        }
 

--- a/class/Admin/Settings.php
+++ b/class/Admin/Settings.php
@@ -334,11 +334,11 @@ class Settings extends SettingsAPI {
 				'sanitize' => array( new CoreFields\Select(), 'sanitize' ),
 			) )
 			->add_field( array(
-				'name'     => __( 'Unfiltered html', 'notification' ),
+				'name'     => __( 'Unfiltered HTML', 'notification' ),
 				'slug'     => 'unfiltered_html',
 				'default'  => 'false',
 				'addons'   => array(
-					'label' => __( 'Allows unfiltered html in email body', 'notification' )
+					'label' => __( 'Allows unfiltered HTML in email body', 'notification' )
 				),
 				'render'   => array( new CoreFields\Checkbox(), 'input' ),
 				'sanitize' => array( new CoreFields\Checkbox(), 'sanitize' ),

--- a/class/Admin/Settings.php
+++ b/class/Admin/Settings.php
@@ -334,6 +334,16 @@ class Settings extends SettingsAPI {
 				'sanitize' => array( new CoreFields\Select(), 'sanitize' ),
 			) )
 			->add_field( array(
+				'name'     => __( 'Unfiltered html', 'notification' ),
+				'slug'     => 'unfiltered_html',
+				'default'  => 'false',
+				'addons'   => array(
+					'label' => __( 'Allows unfiltered html in email body', 'notification' )
+				),
+				'render'   => array( new CoreFields\Checkbox(), 'input' ),
+				'sanitize' => array( new CoreFields\Checkbox(), 'sanitize' ),
+			) )
+			->add_field( array(
 				'name'        => __( 'From Name', 'notification' ),
 				'slug'        => 'from_name',
 				'default'     => '',

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -117,10 +117,17 @@ class Email extends Abstracts\Notification {
     }
 
     /**
+	 * Replace the filtered body with the unfiltered one if the notifications/email/unfiltered_html setting is set to true.
+	 * 
+	 * @param  array $notification_data notification_data from PostData
+	 * @param  string $unfiltered_body the unfiltered message body
+	 * @return array $notification_data with the unfiltered body, if notifications/email/unfiltered_html setting is true
      * @filter notification/allow_unfiltered_body
      **/
     public function allow_unfiltered_body( $notification_data, $unfiltered_body ) {
-		$notification_data['body'] = $unfiltered_body;
+		if ( notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
+			$notification_data['body'] = $unfiltered_body;
+		}
 		return $notification_data;
     }
 }

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -38,7 +38,7 @@ class Email extends Abstracts\Notification {
 			'name'  => 'subject',
 		) ) );
 
-		if ( notification_get_setting( 'notifications/email/type' ) == 'html' ) {
+		if ( notification_get_setting( 'notifications/email/type' ) == 'html' && !notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
 			$body_field = new Field\EditorField( array(
 				'label'    => __( 'Body', 'notification' ),
 				'name'     => 'body',

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -119,9 +119,9 @@ class Email extends Abstracts\Notification {
     /**
 	 * Replace the filtered body with the unfiltered one if the notifications/email/unfiltered_html setting is set to true.
 	 * 
-	 * @param  array $notification_data notification_data from PostData
-	 * @param  string $unfiltered_body the unfiltered message body
-	 * @return array $notification_data with the unfiltered body, if notifications/email/unfiltered_html setting is true
+	 * @param  array  $notification_data notification_data from PostData.
+	 * @param  string $unfiltered_body the unfiltered message body.
+	 * @return array $notification_data with the unfiltered body, if notifications/email/unfiltered_html setting is true.
      * @filter notification/allow_unfiltered_body
      **/
     public function allow_unfiltered_body( $notification_data, $unfiltered_body ) {

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -119,14 +119,14 @@ class Email extends Abstracts\Notification {
     /**
 	 * Replace the filtered body with the unfiltered one if the notifications/email/unfiltered_html setting is set to true.
 	 * 
-	 * @param  array  $notification_data notification_data from PostData.
-	 * @param  string $unfiltered_body the unfiltered message body.
+	 * @param  array $notification_data notification_data from PostData.
+	 * @param  array $ndata ndata from PostData, it contains the unfiltered message body.
 	 * @return array $notification_data with the unfiltered body, if notifications/email/unfiltered_html setting is true.
      * @filter notification/allow_unfiltered_body
      **/
-    public function allow_unfiltered_body( $notification_data, $unfiltered_body ) {
+    public function allow_unfiltered_body( $notification_data, $ndata ) {
 		if ( notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
-			$notification_data['body'] = $unfiltered_body;
+			$notification_data['body'] = $ndata['body'];
 		}
 		return $notification_data;
     }

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -116,4 +116,11 @@ class Email extends Abstracts\Notification {
 
     }
 
+    /**
+     * @filter notification/allow_unfiltered_body
+     **/
+    public function allow_unfiltered_body( $notification_data, $unfiltered_body ) {
+		$notification_data['body'] = $unfiltered_body;
+		return $notification_data;
+    }
 }

--- a/class/Defaults/Notification/Email.php
+++ b/class/Defaults/Notification/Email.php
@@ -38,7 +38,7 @@ class Email extends Abstracts\Notification {
 			'name'  => 'subject',
 		) ) );
 
-		if ( notification_get_setting( 'notifications/email/type' ) == 'html' && !notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
+		if ( notification_get_setting( 'notifications/email/type' ) == 'html' && ! notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
 			$body_field = new Field\EditorField( array(
 				'label'    => __( 'Body', 'notification' ),
 				'name'     => 'body',
@@ -119,12 +119,12 @@ class Email extends Abstracts\Notification {
     /**
 	 * Replace the filtered body with the unfiltered one if the notifications/email/unfiltered_html setting is set to true.
 	 * 
+	 * @filter notification/notification/form/data/values
 	 * @param  array $notification_data notification_data from PostData.
 	 * @param  array $ndata ndata from PostData, it contains the unfiltered message body.
 	 * @return array $notification_data with the unfiltered body, if notifications/email/unfiltered_html setting is true.
-     * @filter notification/allow_unfiltered_body
      **/
-    public function allow_unfiltered_body( $notification_data, $ndata ) {
+    public function notification_form_data_values( $notification_data, $ndata ) {
 		if ( notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
 			$notification_data['body'] = $ndata['body'];
 		}

--- a/inc/defaults/notifications.php
+++ b/inc/defaults/notifications.php
@@ -8,9 +8,14 @@
 use BracketSpace\Notification\Defaults\Notification;
 
 if ( notification_get_setting( 'notifications/email/enable' ) ) {
-	register_notification( new Notification\Email() );
+	$email = new Notification\Email();
+	register_notification( $email );
+	if ( notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
+		notification_runtime()->add_hooks( $email );
+	}
 }
 
 if ( notification_get_setting( 'notifications/webhook/enable' ) ) {
 	register_notification( new Notification\Webhook() );
 }
+

--- a/inc/defaults/notifications.php
+++ b/inc/defaults/notifications.php
@@ -10,9 +10,7 @@ use BracketSpace\Notification\Defaults\Notification;
 if ( notification_get_setting( 'notifications/email/enable' ) ) {
 	$email = new Notification\Email();
 	register_notification( $email );
-	if ( notification_get_setting( 'notifications/email/unfiltered_html' ) ) {
-		notification_runtime()->add_hooks( $email );
-	}
+	notification_runtime()->add_hooks( $email );
 }
 
 if ( notification_get_setting( 'notifications/webhook/enable' ) ) {


### PR DESCRIPTION
Hi, I've added a new option in settings to allow unfiltered html in email body.
The default value is false so the behaviour of the plugin doesn't change, unless this option is not enabled explicitly.
Once the option is enabled the EditorField is disabled and TextareaField is used in place, this is needed because the editor, in visual mode, mess up with unfiltered html.
The utility of this is to be able to use complex html templates.


On a side note, I'd like to contribute adding an italian translation. Should I do this on translate.wordpress.org or is there any other way?