### PR TITLE
Bedrock compatiblity

### DIFF
--- a/notification.php
+++ b/notification.php
@@ -14,7 +14,7 @@
 
 define( 'NOTIFICATION_VERSION', '6.0.4' );
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once dirname(__FILE__) . '/vendor/autoload.php';
 
 /**
  * Requirements check

--- a/notification.php
+++ b/notification.php
@@ -14,7 +14,7 @@
 
 define( 'NOTIFICATION_VERSION', '6.0.4' );
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 /**
  * Requirements check

--- a/notification.php
+++ b/notification.php
@@ -14,7 +14,7 @@
 
 define( 'NOTIFICATION_VERSION', '6.0.4' );
 
-require_once dirname(__FILE__) . '/vendor/autoload.php';
+require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 
 /**
  * Requirements check


### PR DESCRIPTION
I used wordpress bedrock and with you plugin I reach this error:
```
PHP Fatal error:  Uncaught Error: Class 'BracketSpace\Notification\Utils\Requirements' not found in C:\Users\<bedrock-installation>\web\app\plugins\notification\notification.php:22
Stack trace:
#0 C:\Users\<bedrock-installation>\web\wp\wp-settings.php(362): include_once()
#1 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1209): require('C:\\Users\\<bedro...')
#2 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1130): WP_CLI\Runner->load_wordpress()
#3 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#4 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#5 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#6 phar://C:/wp-cli/wp-cli.phar/php/boot-phar.php(11): include('phar://C:/wp-cl...')
#7 C:\wp-cli\wp-cli.phar(4):  in C:\Users\<bedrock-installation>\web\app\plugins\notification\notification.php on line 22
Fatal error: Uncaught Error: Class 'BracketSpace\Notification\Utils\Requirements' not found in C:\Users\<bedrock-installation>\web\app\plugins\notification\notification.php:22
Stack trace:
#0 C:\Users\<bedrock-installation>\web\wp\wp-settings.php(362): include_once()
#1 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1209): require('C:\\Users\\<bedro...')
#2 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1130): WP_CLI\Runner->load_wordpress()
#3 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#4 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#5 phar://C:/wp-cli/wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#6 phar://C:/wp-cli/wp-cli.phar/php/boot-phar.php(11): include('phar://C:/wp-cl...')
#7 C:\wp-cli\wp-cli.phar(4):  in C:\Users\<bedrock-installation>\web\app\plugins\notification\notification.php on line 22
```

When I run any wp-cli command this error occurs. Just with this little modifications, my error gone.