### PR TITLE
Allow forward slash in filter-id

### DIFF
--- a/src/classes/Defaults/Recipient/Email.php
+++ b/src/classes/Defaults/Recipient/Email.php
@@ -49,7 +49,7 @@ class Email extends Abstracts\Recipient {
 
 		if ( preg_match( '/\bfilter-id:([\w][\w-]*)/', $value, $matches ) ) {
 			$filter_id = $matches[1];
-			$value     = trim( preg_replace( '/\bfilter-id:[\w][\w-]*/', '', $value ) );
+			$value     = trim( preg_replace( '/\bfilter-id:[\w][\w-\/]*/', '', $value ) );
 		}
 
 		$value = apply_filters( 'notification/recipient/email/' . $filter_id, $value );


### PR DESCRIPTION
I'd like to organize my filters a bit with '/' separation and find it's not allowed.

Note this change is simple, but untested (what could go wrong?  :)