### PR TITLE
Set min PHP and WordPress versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"wp-coding-standards/wpcs": "^2.0",
 		"phpunit/phpunit": "^6.5",
 		"wp-phpunit/wp-phpunit": "^5.6",
-		"roots/wordpress": "^5.6"
+		"roots/wordpress": "~4.9"
 	},
 	"autoload": {
 		"psr-4": {
@@ -43,6 +43,7 @@
 		}
 	},
 	"require": {
+		"php": "^5.6 || ^7.0",
 		"micropackage/requirements": "^1.0",
 		"micropackage/dochooks": "^1.0",
 		"micropackage/filesystem": "^1.1",
@@ -61,6 +62,6 @@
 		"wordpress-install-dir": "tests/_wordpress"
 	},
 	"config": {
-        "platform-check": false
-    }
+		"platform-check": false
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3e2de3ad374ea423f6bb8296c6eafa7",
+    "content-hash": "53156f042a5d27d5944f735e7bb6e1f6",
     "packages": [
         {
             "name": "micropackage/ajax",
@@ -1482,15 +1482,15 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.6",
+            "version": "4.9.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.6"
+                "reference": "4.9.16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.6"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/4.9.16"
             },
             "require": {
                 "php": ">=5.3.2",
@@ -1533,7 +1533,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2020-12-08T22:15:57+00:00"
+            "time": "2020-10-29T20:06:45+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -2582,7 +2582,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^5.6 || ^7.0"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,7 +31,8 @@
 
 	<!-- PHPCompatibility -->
 	<rule ref="PHPCompatibility" />
-	<config name="testVersion" value="7.0-" />
+	<config name="testVersion" value="5.6-" />
+	<config name="minimum_supported_wp_version" value="4.9"/>
 
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>


### PR DESCRIPTION
The package was required but misconfigured.

> null coalescing operator (??) is not present in PHP version 5.6 or earlier

https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters

From #317