### PR TITLE
Don't bother unauthorized users with back-end access

### DIFF
--- a/src/classes/Admin/Extensions.php
+++ b/src/classes/Admin/Extensions.php
@@ -414,6 +414,10 @@ class Extensions {
 			return;
 		}
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		
 		if ( get_current_screen()->id === $this->page_hook ) {
 			return;
 		}


### PR DESCRIPTION
I have few users with back-end access but they can't manage_options nor mess with licenses and so on.

They should not see the notifications about licenses.

Temporary disabled with notification/whitelabel filter.