### PR TITLE
Remove duplicated init from load.php

### DIFF
--- a/load.php
+++ b/load.php
@@ -9,10 +9,3 @@
  * Load the main plugin file.
  */
 require_once __DIR__ . '/notification.php';
-
-/**
- * Initialize early.
- */
-add_action( 'init', function() {
-	Notification::init( __FILE__ )->init();
-}, 4 );


### PR DESCRIPTION
Already done in https://github.com/BracketSpace/Notification/blob/cfa33f53c16badf26a17e5dc591788fadcfe03d1/notification.php#L95-L97

Can we delete `load.php`?