### PR TITLE
Fix PHP Error in Webhook

### DIFF
--- a/src/Traits/Webhook.php
+++ b/src/Traits/Webhook.php
@@ -32,7 +32,7 @@ trait Webhook {
 	 * @param  string $method  HTTP request method.
 	 * @return void
 	 */
-	public function http_request( $url, $args = [], $headers = [], $method ) {
+	public function http_request( $url, $args = [], $headers = [], $method = 'GET' ) {
 		$remote_args = apply_filters(
 			"notification/carrier/webhook/remote_args/{$method}",
 			[


### PR DESCRIPTION
A required parameter follows optional parameters causing issues in newer versions of PHP. PHP Deprecated:  Required parameter $method follows optional parameter $args.

The fix is just to add a reasonable default for method.